### PR TITLE
Make jit library independent of base/types.h

### DIFF
--- a/third_party/jit/BUILD
+++ b/third_party/jit/BUILD
@@ -1,21 +1,24 @@
+# x64 jit assembler.
+
 package(default_visibility = ["//visibility:public"])
 
-licenses(["notice"])
+licenses(["notice"]) # BSD
 
 exports_files(["LICENSE"])
 
 cc_library(
-  name = "memory",
-  hdrs = ["memory.h"],
+  name = "types",
+  hdrs = ["types.h"],
   deps = [
     "//base",
   ],
 )
 
 cc_library(
-  name = "types",
-  hdrs = ["types.h"],
+  name = "memory",
+  hdrs = ["memory.h"],
   deps = [
+    ":types",
     "//base",
   ],
 )

--- a/third_party/jit/assembler.cc
+++ b/third_party/jit/assembler.cc
@@ -35,7 +35,6 @@
 
 #include "third_party/jit/assembler.h"
 
-#include "base/bitcast.h"
 #include "base/logging.h"
 #include "base/macros.h"
 #include "third_party/jit/cpu.h"
@@ -44,6 +43,18 @@
 
 namespace sling {
 namespace jit {
+
+// bit_cast<Dest,Source> is a template function that implements the
+// equivalent of "*reinterpret_cast<Dest*>(&source)".
+template <class Dest, class Source>
+inline Dest bit_cast(const Source& source) {
+  static_assert(sizeof(Dest) == sizeof(Source),
+                "Source and destination types should have equal sizes.");
+
+  Dest dest;
+  memcpy(&dest, &source, sizeof(dest));
+  return dest;
+}
 
 // Returns true iff value is a power of 2.
 static bool IsPowerOfTwo32(uint32_t value) {

--- a/third_party/jit/assembler.h
+++ b/third_party/jit/assembler.h
@@ -37,7 +37,6 @@
 #define JIT_ASSEMBLER_H_
 
 #include "base/logging.h"
-#include "base/types.h"
 #include "third_party/jit/code.h"
 #include "third_party/jit/cpu.h"
 #include "third_party/jit/instructions.h"

--- a/third_party/jit/memory.h
+++ b/third_party/jit/memory.h
@@ -28,7 +28,7 @@
 #ifndef JIT_MEMORY_H_
 #define JIT_MEMORY_H_
 
-#include "base/types.h"
+#include "third_party/jit/types.h"
 
 namespace sling {
 namespace jit {

--- a/third_party/jit/types.h
+++ b/third_party/jit/types.h
@@ -28,8 +28,9 @@
 #ifndef JIT_TYPES_H_
 #define JIT_TYPES_H_
 
+#include <stdint.h>
+
 #include "base/logging.h"
-#include "base/types.h"
 
 namespace sling {
 namespace jit {


### PR DESCRIPTION
The jit library cannot have cross-dependencies with the rest of the SLING code because it needs to be built separately for google3, so I have removed the dependencies on base/types.h and base/bitcast.h.