### PR TITLE
Fix bug in CHECK_OK macro

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+bazel-bin
+bazel-genfiles
+bazel-sling
+bazel-google3
+bazel-out
+bazel-testlogs
+examples
+local
+

--- a/base/status.h
+++ b/base/status.h
@@ -88,7 +88,11 @@ inline std::ostream &operator<<(std::ostream &out, const Status &status) {
   return out;
 }
 
-#define CHECK_OK(status) CHECK((status).ok()) << (status).ToString()
+#define CHECK_OK(op) \
+  do { \
+    sling::Status st = (op); \
+    if (!st.ok()) LOG(FATAL) << st.ToString(); \
+  } while (0) \
 
 }  // namespace sling
 


### PR DESCRIPTION
The CHECK_OK macro would re-execute the op in case of failure. I have fixed this problem. I have also included a .gitignore file to prevent adding generated and local files from being added to the commits.