### PR TITLE
Move registry into sling namespace

### DIFF
--- a/base/registry.cc
+++ b/base/registry.cc
@@ -14,11 +14,54 @@
 
 #include "base/registry.h"
 
+namespace sling {
+
 // Global list of all component registries.
-RegistryMetadata *global_registry_list = nullptr;
+RegistryMetadata *RegistryMetadata::global_registry_list = nullptr;
+
+void RegistryMetadata::GetComponents(
+    std::vector<const ComponentMetadata *> *components) const {
+  components->clear();
+  ComponentMetadata *meta = *components_;
+  while (meta != nullptr) {
+    components->push_back(meta);
+    meta = meta->link();
+  }
+}
+
+const ComponentMetadata *RegistryMetadata::GetComponent(
+    const string &name) const {
+  ComponentMetadata *meta = *components_;
+  while (meta != nullptr) {
+    if (name == meta->name()) return meta;
+    meta = meta->link();
+  }
+  return nullptr;
+}
 
 void RegistryMetadata::Register(RegistryMetadata *registry) {
   registry->set_link(global_registry_list);
   global_registry_list = registry;
 }
+
+void RegistryMetadata::GetRegistries(
+    std::vector<const RegistryMetadata *> *registries) {
+  registries->clear();
+  RegistryMetadata *meta = global_registry_list;
+  while (meta != nullptr) {
+    registries->push_back(meta);
+    meta = meta->next();
+  }
+}
+
+const RegistryMetadata *RegistryMetadata::GetRegistry(const string &name) {
+  RegistryMetadata *meta = global_registry_list;
+  while (meta != nullptr) {
+    if (name == meta->name()) return meta;
+    meta = meta->next();
+  }
+  return nullptr;
+}
+
+}  // namespace sling
 

--- a/file/file.cc
+++ b/file/file.cc
@@ -25,7 +25,7 @@
 #include "base/types.h"
 
 // Registry for file systems.
-REGISTER_INSTANCE_REGISTRY("file system", sling::FileSystem);
+REGISTER_SINGLETON_REGISTRY("file system", sling::FileSystem);
 
 namespace sling {
 namespace {

--- a/file/file.h
+++ b/file/file.h
@@ -157,7 +157,7 @@ class File {
 };
 
 // Abstract file system interface.
-class FileSystem : public RegisterableInstance<FileSystem> {
+class FileSystem : public Singleton<FileSystem> {
  public:
   virtual ~FileSystem() = default;
 
@@ -202,7 +202,7 @@ class FileSystem : public RegisterableInstance<FileSystem> {
 }  // namespace sling
 
 #define REGISTER_FILE_SYSTEM(name, component) \
-  REGISTER_INSTANCE_COMPONENT(sling::FileSystem, name, component)
+  REGISTER_SINGLETON_TYPE(sling::FileSystem, name, component)
 
 #endif  // FILE_FILE_H_
 

--- a/tools/buildall.sh
+++ b/tools/buildall.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+bazel build -c opt \
+  base:* \
+  file:* \
+  frame:* \
+  myelin:* \
+  myelin/kernel:* \
+  nlp/document:* \
+  nlp/parser:* \
+  nlp/parser/trainer:* \
+  stream:* \
+  string:* \
+  util:* \
+  web:* \
+


### PR DESCRIPTION
The registry has historically been one of the few components in the global namespace. This conflicts with other copies of the registry component, e.g. google3 and dragnn. I have moved the registry to the sling namespace to avoid conflicts and renamed the class names and macros. The new version also has some of the missing metadata methods that was missing in the initial version.

I have also included a simple script to build all components. This is useful for testing if all the code builds.