### PR TITLE
Put dtype in correct place in flow file BNF.

### DIFF
--- a/myelin/README.md
+++ b/myelin/README.md
@@ -189,8 +189,9 @@ flow = "flow" <version>
        <#cnxs> cnx*
        <#blobs> blob* (from version 4)
 
-var = <name$> <dtype$>
+var = <name$>
       <#aliases> <alias$>
+      <dtype$>
       <shape>
       <#bytes> value
 


### PR DESCRIPTION
flow.cc reads the aliases before the dtype:
https://github.com/google/sling/blob/master/myelin/flow.cc#L589