### PR TITLE
Propagates Variable.ref in Flow::Eliminate()

### DIFF
--- a/myelin/flow.cc
+++ b/myelin/flow.cc
@@ -1141,6 +1141,7 @@ void Flow::Eliminate(Operation *op) {
     }
     if (output->in) input->in = true;
     if (output->out) input->out = true;
+    if (output->ref) input->ref = true;
     for (Operation *target : ops_) {
       for (int i = 0; i < target->inputs.size(); ++i) {
         if (target->inputs[i] == output) {


### PR DESCRIPTION
I ran into an issue where the ref-ness of a Variable disappeared after flow analysis.  I think the issue was that the output node was spliced out by Eliminate(), which hadn't been preserving ref-ness---or at least this change made the issue go away.  I think it's reasonable because the neighboring code also propagates other properties like Variable.{in,out}.