### PR TITLE
Also graph consumer edges as outputs.

### DIFF
--- a/myelin/graph.cc
+++ b/myelin/graph.cc
@@ -176,7 +176,8 @@ static void AppendVar(string *str,
       str->append("];\n");
     }
   }
-  if (var->out && var->producer != nullptr) {
+  if (var->out) {
+    if (var->producer != nullptr) {
       AppendOpId(str, var->producer);
       str->append(" -> ");
       AppendVarId(str, var);
@@ -186,6 +187,18 @@ static void AppendVar(string *str,
       str->append("\" ");
       AppendPenWidth(str, var, options);
       str->append("];\n");
+    }
+    for (Flow::Operation *consumer : var->consumers) {
+      AppendVarId(str, var);
+      str->append(" -> ");
+      AppendOpId(str, consumer);
+      str->append(" [");
+      str->append("tooltip=\"");
+      str->append(var->name);
+      str->append("\" ");
+      AppendPenWidth(str, var, options);
+      str->append("];\n");
+    }
   }
 }
 


### PR DESCRIPTION
The DOT produced by graph.cc omits the outbound edges of Variables with .out=true.  This is probably because such Variable nodes typically don't have outputs, but this is not the case in DRAGNN networks.

For example, consider a FeedForwardNetwork (i.e., multi-layer perceptron) with 2 hidden layers and a softmax.  DRAGNN considers this network cell to have 3 outputs: hidden layer 0, hidden layer 1, and the softmax logits.  (I.e., other DRAGNN components may access any of those values).  Since the outputs for hidden layers 0 and 1 are also consumed by other parts of the network cell, they should have their consumers attached.  Here are some graphs to illustrate:

Before this change, the cell is rendered as three disjoint subgraphs (even though the cell is still a single connected component):
![tagger-original before](https://user-images.githubusercontent.com/26583555/30300924-34a61c18-970c-11e7-8273-0414697e5e2a.png)

After this change, everything is rendered as the same connected component:
![tagger-original after](https://user-images.githubusercontent.com/26583555/30300923-34a48010-970c-11e7-8966-0008cb607ea0.png)

Additional examples found here:
http://www/~terrykoo/no_crawl/flows/before
http://www/~terrykoo/no_crawl/flows/after