### PR TITLE
F16C CPU feature flag

### DIFF
--- a/myelin/profile.cc
+++ b/myelin/profile.cc
@@ -121,6 +121,7 @@ string Profile::ASCIIReport() const {
   if (jit::CPU::Enabled(jit::SSE3)) report.append(" SSE3");
   if (jit::CPU::Enabled(jit::SSE4_1)) report.append(" SSE4.1");
   if (jit::CPU::Enabled(jit::SSE4_2)) report.append(" SSE4.2");
+  if (jit::CPU::Enabled(jit::F16C)) report.append(" F16C");
   if (jit::CPU::Enabled(jit::AVX)) report.append(" AVX");
   if (jit::CPU::Enabled(jit::AVX2)) report.append(" AVX2");
   if (jit::CPU::Enabled(jit::FMA3)) report.append(" FMA3");

--- a/third_party/jit/cpu.cc
+++ b/third_party/jit/cpu.cc
@@ -94,6 +94,7 @@ ProcessorInformation::ProcessorInformation() {
     has_ssse3_ = (cpu_info[2] & 0x00000200) != 0;
     has_sse41_ = (cpu_info[2] & 0x00080000) != 0;
     has_sse42_ = (cpu_info[2] & 0x00100000) != 0;
+    has_f16c_ = (cpu_info[2] & 0x20000000) != 0;
     has_popcnt_ = (cpu_info[2] & 0x00800000) != 0;
     has_osxsave_ = (cpu_info[2] & 0x08000000) != 0;
     has_avx_ = (cpu_info[2] & 0x10000000) != 0;
@@ -229,6 +230,7 @@ void CPU::Initialize() {
   if (cpu.has_sse3()) features |= 1u << SSE3;
   if (cpu.has_ssse3()) features |= 1u << SSSE3;
   if (cpu.has_sse41()) features |= 1u << SSE4_1;
+  if (cpu.has_f16c()) features |= 1u << F16C;
   if (cpu.has_sahf()) features |= 1u << SAHF;
 
   if (cpu.has_osxsave() && os_has_avx_support()) {

--- a/third_party/jit/cpu.h
+++ b/third_party/jit/cpu.h
@@ -70,6 +70,7 @@ class ProcessorInformation {
   bool has_ssse3() const { return has_ssse3_; }
   bool has_sse41() const { return has_sse41_; }
   bool has_sse42() const { return has_sse42_; }
+  bool has_f16c() const { return has_f16c_; }
   bool has_osxsave() const { return has_osxsave_; }
   bool has_avx() const { return has_avx_; }
   bool has_avx2() const { return has_avx2_; }
@@ -101,6 +102,7 @@ class ProcessorInformation {
   bool has_ssse3_ = false;
   bool has_sse41_ = false;
   bool has_sse42_ = false;
+  bool has_f16c_ = false;
   bool has_osxsave_ = false;
   bool has_avx_ = false;
   bool has_avx2_ = false;
@@ -122,6 +124,7 @@ enum CpuFeature {
   SSSE3,
   SSE4_1,
   SSE4_2,
+  F16C,
   AVX,
   AVX2,
   FMA3,


### PR DESCRIPTION
Support for F16C CPU feature flag for 16-bit IEEE floating point instructions.