### PR TITLE
fix for missing INFINITY constant

### DIFF
--- a/nlp/parser/parser.cc
+++ b/nlp/parser/parser.cc
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <math.h>
+
 #include "nlp/parser/parser.h"
 
 #include "frame/serialization.h"


### PR DESCRIPTION
On Ubuntu 17.04, build process would complain about missing definition for INFINITY. Adding this include helps. I haven't upgraded to 17.10 yet, so not sure if it works there.