### PR TITLE
Add link to detailed frame documentation in SLING readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ can be seen below. It is best to create one SLING document per input sentence.
   }
 }
 ```
-For writing your converter or getting better hold of concept of frames and store in SLING, you can have a look at detailed deep dive on frames and stores [here](sling/frame/README.md).
+For writing your converter or getting a better hold of the concepts of frames and store in SLING, you can have a look at detailed deep dive on frames and stores [here](sling/frame/README.md).
 
 The SLING [Document class](sling/nlp/document/document.h)
 also has methods to incrementally make such document frames, e.g.


### PR DESCRIPTION
Adding this link would much better explain detailed concept of frames and store than what is available in root readme of SLING. 

I believe that the detailed introduction of frame is quite useful for someone trying to train their own models. 