### PR TITLE
Make suffix features identical across LexicalEncoder and Python trainer

### DIFF
--- a/sling/nlp/document/affix.cc
+++ b/sling/nlp/document/affix.cc
@@ -153,7 +153,7 @@ Affix *AffixTable::AddAffixesForWord(Text word) {
   // Try to find successively shorter affixes.
   Affix *top = nullptr;
   Affix *ancestor = nullptr;
-  while (affix_len > -1) {
+  while (affix_len >= 0) {
     // Try to find affix in table.
     Text s(start, end - start);
     Affix *affix = FindAffix(s);

--- a/sling/nlp/document/affix.cc
+++ b/sling/nlp/document/affix.cc
@@ -182,7 +182,7 @@ Affix *AffixTable::AddAffixesForWord(Text word) {
     affix_len--;
   }
 
-  CHECK(top != nullptr);   // Make DCHECK
+  DCHECK(top != nullptr);
   return top;
 }
 
@@ -251,7 +251,7 @@ Affix *AffixTable::GetLongestAffix(Text word) const {
     while (p >= start) {
       Affix *affix = FindAffix(Text(start, p - start));
       if (affix != nullptr) return affix;
-      CHECK_GT(p, start);  // Make DCHECK_GT
+      DCHECK_GT(p, start);
       p = UTF8::Previous(p);
     }
   } else {
@@ -260,11 +260,12 @@ Affix *AffixTable::GetLongestAffix(Text word) const {
     while (p <= end) {
       Affix *affix = FindAffix(Text(p, end - p));
       if (affix != nullptr) return affix;
-      CHECK_LT(p, end);  // Make DCHECK_LT
+      DCHECK_LT(p, end);
       p = UTF8::Next(p);
     }
   }
-  CHECK(false);  // Should not reach here. Make DCHECK.
+
+  LOG(FATAL) << "Should not reach here:" << word;
   return nullptr;
 }
 

--- a/sling/nlp/document/affix.cc
+++ b/sling/nlp/document/affix.cc
@@ -90,7 +90,7 @@ void AffixTable::Read(InputStream *stream) {
     DCHECK_LE(length, max_length_);
     DCHECK(FindAffix(form) == nullptr);
     Affix *affix = AddNewAffix(form, length);
-    CHECK_EQ(affix->id(), affix_id);
+    DCHECK_EQ(affix->id(), affix_id);
   }
   DCHECK_EQ(size, affixes_.size());
 
@@ -98,7 +98,7 @@ void AffixTable::Read(InputStream *stream) {
   for (int affix_id = 0; affix_id < size; ++affix_id) {
     Affix *affix = affixes_[affix_id];
     if (link[affix_id] == -1) {
-      CHECK_EQ(affix->length(), 0);
+      DCHECK_EQ(affix->length(), 0);
       affix->set_shorter(nullptr);
       continue;
     }

--- a/sling/nlp/document/affix.h
+++ b/sling/nlp/document/affix.h
@@ -136,9 +136,6 @@ class AffixTable {
   // Maximum length of affix.
   int max_length_;
 
-  // Empty affix.
-  Affix *empty_ = nullptr;
-
   // Index from affix ids to affix items.
   std::vector<Affix *> affixes_;
 

--- a/sling/nlp/document/lexical-encoder.cc
+++ b/sling/nlp/document/lexical-encoder.cc
@@ -316,71 +316,6 @@ int LexicalFeatures::InitWordEmbeddings(const string &filename) {
   return found;
 };
 
-void print(const string &f, const Document &doc, int i, int val,
-  string val_str="") {
-  std::cout << "LEXDEBUG " << f << " token " << i << " ("
-            << doc.token(i).text() << ") = " << val;
-  if (f == "suffix") std::cout << " Value=(" << val_str << ")";
-  std::cout << "\n";
-}
-
-void LexicalFeatureExtractor::PrintFeatures(
-    const DocumentFeatures &f,
-    const Document &doc, int begin, int end) {
-  if (end == -1) end = doc.num_tokens();
-  if (lex_.word_feature_) {
-    for (int i = begin; i < end; ++i) {
-      print("word", doc, i, f.word(i - begin));
-    }
-  }
-  if (lex_.suffix_feature_) {
-    for (int i = begin; i < end; ++i) {
-      Affix *affix = f.suffix(i - begin);
-      while (affix != nullptr) {
-        print("suffix", doc, i, affix->id(), affix->form());
-        affix = affix->shorter();
-      }
-    }
-  }
-  if (lex_.prefix_feature_) {
-    for (int i = begin; i < end; ++i) {
-      Affix *affix = f.prefix(i - begin);
-      while (affix != nullptr) {
-        print("prefix", doc, i, affix->id(), affix->form());
-        affix = affix->shorter();
-      }
-    }
-  }
-
-
-  if (lex_.caps_feature_) {
-    for (int i = begin; i < end; ++i) {
-      print("capitalization", doc, i, f.capitalization(i - begin));
-    }
-  }
-
-  if (lex_.hyphen_feature_) {
-    for (int i = begin; i < end; ++i) {
-      print("hyphen", doc, i, f.hyphen(i - begin));
-    }
-  }
-  if (lex_.punct_feature_) {
-    for (int i = begin; i < end; ++i) {
-      print("punctuation", doc, i, f.punctuation(i - begin));
-    }
-  }
-  if (lex_.quote_feature_) {
-    for (int i = begin; i < end; ++i) {
-      print("quote", doc, i, f.quote(i - begin));
-    }
-  }
-  if (lex_.digit_feature_) {
-    for (int i = begin; i < end; ++i) {
-      print("digit", doc, i, f.digit(i - begin));
-    }
-  }
-}
-
 void LexicalFeatureExtractor::Compute(const DocumentFeatures &features,
                                       int index, float *fv) {
   // Extract word feature.
@@ -453,7 +388,6 @@ void LexicalFeatureExtractor::Extract(const Document &document,
   // Extract lexical features from document.
   DocumentFeatures features(&lex_.lexicon_);
   features.Extract(document, begin, end);
-  PrintFeatures(features, document, begin, end);
 
   // Compute feature vectors.
   int length = end - begin;

--- a/sling/nlp/document/lexical-encoder.cc
+++ b/sling/nlp/document/lexical-encoder.cc
@@ -14,8 +14,6 @@
 
 #include "sling/nlp/document/lexical-encoder.h"
 
-#include <iostream>
-
 #include "sling/myelin/builder.h"
 #include "sling/myelin/gradient.h"
 #include "sling/util/embeddings.h"

--- a/sling/nlp/document/lexical-encoder.h
+++ b/sling/nlp/document/lexical-encoder.h
@@ -113,9 +113,6 @@ class LexicalFeatures {
   myelin::Tensor *feature_vector_ = nullptr;   // output feature vector
   myelin::Tensor *word_embeddings_ = nullptr;  // word embedding matrix
 
-  int prefix_size_ = 0;                        // max prefix length
-  int suffix_size_ = 0;                        // max suffix length
-
   myelin::Cell *gfeatures_ = nullptr;          // gradient cell
   myelin::Tensor *d_feature_vector_;           // feature vector gradient
   myelin::Tensor *primal_;                     // reference to primal cell
@@ -133,6 +130,9 @@ class LexicalFeatureExtractor {
 
   // Compute feature vector for token.
   void Compute(const DocumentFeatures &features, int index, float *fv);
+
+  void PrintFeatures(const DocumentFeatures &features, const Document &doc,
+      int begin, int end);
 
   // Extract lexical features from a range of tokens in a document and output
   // the feature vectors to a channel.

--- a/sling/nlp/document/lexical-encoder.h
+++ b/sling/nlp/document/lexical-encoder.h
@@ -131,9 +131,6 @@ class LexicalFeatureExtractor {
   // Compute feature vector for token.
   void Compute(const DocumentFeatures &features, int index, float *fv);
 
-  void PrintFeatures(const DocumentFeatures &features, const Document &doc,
-      int begin, int end);
-
   // Extract lexical features from a range of tokens in a document and output
   // the feature vectors to a channel.
   void Extract(const Document &document, int begin, int end,

--- a/sling/nlp/document/lexicon.cc
+++ b/sling/nlp/document/lexicon.cc
@@ -173,6 +173,7 @@ void Lexicon::BuildPrefixes(int max_prefix) {
       entry.prefix = prefixes_.AddAffixesForWord(entry.word);
     }
   }
+  prefixes_.AddAffixesForWord("");
 }
 
 void Lexicon::BuildSuffixes(int max_suffix) {
@@ -182,6 +183,7 @@ void Lexicon::BuildSuffixes(int max_suffix) {
       entry.suffix = suffixes_.AddAffixesForWord(entry.word);
     }
   }
+  suffixes_.AddAffixesForWord("");
 }
 
 void Lexicon::PrecomputeShapes() {

--- a/sling/nlp/document/lexicon.cc
+++ b/sling/nlp/document/lexicon.cc
@@ -168,22 +168,22 @@ void Lexicon::WriteSuffixes(string *buffer) const {
 
 void Lexicon::BuildPrefixes(int max_prefix) {
   prefixes_.Reset(max_prefix);
+  prefixes_.AddAffixesForWord("");
   if (max_prefix > 0) {
     for (Entry &entry : words_) {
       entry.prefix = prefixes_.AddAffixesForWord(entry.word);
     }
   }
-  prefixes_.AddAffixesForWord("");
 }
 
 void Lexicon::BuildSuffixes(int max_suffix) {
   suffixes_.Reset(max_suffix);
+  suffixes_.AddAffixesForWord("");
   if (max_suffix > 0) {
     for (Entry &entry : words_) {
       entry.suffix = suffixes_.AddAffixesForWord(entry.word);
     }
   }
-  suffixes_.AddAffixesForWord("");
 }
 
 void Lexicon::PrecomputeShapes() {

--- a/sling/nlp/parser/trainer/pytorch_modules.py
+++ b/sling/nlp/parser/trainer/pytorch_modules.py
@@ -385,6 +385,7 @@ class Caspar(nn.Module):
   def _lstm_outputs(self, document):
     # Compute all raw token features just once for both the LSTMs.
     raw_features = self.spec.raw_lstm_features(document)
+    self.spec.print_lstm_features(document, raw_features)
     length = document.size()
 
     # 'lstm_inputs' should have shape (length, lstm_input_dim).

--- a/sling/nlp/parser/trainer/pytorch_modules.py
+++ b/sling/nlp/parser/trainer/pytorch_modules.py
@@ -385,7 +385,6 @@ class Caspar(nn.Module):
   def _lstm_outputs(self, document):
     # Compute all raw token features just once for both the LSTMs.
     raw_features = self.spec.raw_lstm_features(document)
-    self.spec.print_lstm_features(document, raw_features)
     length = document.size()
 
     # 'lstm_inputs' should have shape (length, lstm_input_dim).


### PR DESCRIPTION
- The Python trainer didn't have the empty affix, so it has been added there.
- Since the empty affix is present by default in AffixTable (cf. Reset()), we shouldn't add it again while reading an AffixTable. 
- The python trainer now mimics the affix computation logic in the parser, viz. given a normalized word W, a max affix length L, and an affix table T:
a) Get the longest affix A for W in T. If none exists, return the empty affix as the sole result.
b) Return max(len(A), L) suffixes of A
c) If len(A) < L, additionally return the empty affix.