### PR TITLE
Fix benign error in KB UI.

### DIFF
--- a/sling/nlp/kb/app/kb.js
+++ b/sling/nlp/kb/app/kb.js
@@ -43,8 +43,10 @@ app.controller('SearchCtrl', function($http,  $location) {
   }
 
   self.selectedItemChange = function(item) {
-    console.log('Navigate to item ' + item.ref);
-    $location.search('id', item.ref);
+    if (item) {
+      console.log('Navigate to item ' + item.ref);
+      $location.search('id', item.ref);
+    }
   }
 })
 


### PR DESCRIPTION
When deleting characters from the search bar the update handler gets a
null item. Check it before dereferencing `.ref` on it.

For reference, the console error:

    TypeError: Cannot read property 'ref' of undefined
        at Object.self.selectedItemChange (kb.js:46)
        at fn (eval at compile (angular.js:14605), <anonymous>:4:318)
        at m.d.(:8080/kb/anonymous function) [as itemChange] (http://ajax.googleapis.com/ajax/libs/angularjs/1.5.7/angular.min.js:83:232)
        at D (angular-material.min.js:13)
        at N (angular-material.min.js:13)
        at m.$digest (angular.js:17286)
        at b.$apply (angular.js:17552)
        at Pg.$$debounceViewValueCommit (angular.js:27516)
        at Pg.$setViewValue (angular.js:27488)
        at HTMLInputElement.l (angular.js:23730)