### PR TITLE
Tweaks to the Wikicat browser

### DIFF
--- a/sling/nlp/wikicat/app/index.html
+++ b/sling/nlp/wikicat/app/index.html
@@ -172,7 +172,11 @@
           <td>{{$index}}</td>
           <td>
             <span pointer ng-click='browseSignature(parse.signature)'>
-            {{parse.signature}}
+              <span ng-repeat='part in parse.name_parts'
+               class='{{part.pqid == "" ? "" : "span_qid"}}'
+               title='{{part.pqid == "" ? "" : part.pqid}}'>
+               {{part.text}}
+              </span>
             </span>
           </td>
           <td>{{parse.score}}</td>


### PR DESCRIPTION
- Push parse scoring before dedup so that low scoring dupes are removed (as opposed to the last k).
- Some code clean up.
- Add an id field to each parse, for future use.