### PR TITLE
Fix wget missing URL error while installing Bazel in setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -23,7 +23,7 @@ BAZELURL=${BAZELREPO}/releases/download/${BAZELVER}/${BAZELSH}
 if ! which bazel > /dev/null; then
   echo
   echo "=== Install Bazel build system"
-  wget -P ${BAZELURL}
+  wget -P /tmp ${BAZELURL}
   chmod +x /tmp/${BAZELSH}
   sudo /tmp/${BAZELSH}
   rm /tmp/${BAZELSH}


### PR DESCRIPTION
While installing Bazel through the setup script, the `wget` command is missing a directory prefix parameter
```
=== Install Bazel build system
wget: missing URL
Usage: wget [OPTION]... [URL]...

Try `wget --help' for more options.
```
Added the directory prefix `/tmp` to fix this problem at line [26](https://github.com/google/sling/blob/bb45740f2db07c18ae8af94f6439b109c56be17a/setup.sh#L26)
```
  wget -P /tmp ${BAZELURL}
```
 

