### PR TITLE
Make frame types optional in the trainer

### DIFF
--- a/sling/nlp/parser/trainer/parser_state.py
+++ b/sling/nlp/parser/trainer/parser_state.py
@@ -330,7 +330,9 @@ class ParserState:
     frames = {}
 
     for f in self.frames:
-      frame = store.frame({"isa": f.type})
+      frame = store.frame({})
+      if f.type is not None:
+        frame["isa"] = f.type
       frames[f] = frame
       if len(f.spans) == 0:
         document.add_theme(frame)

--- a/sling/nlp/parser/trainer/transition_generator.py
+++ b/sling/nlp/parser/trainer/transition_generator.py
@@ -52,8 +52,6 @@ class TransitionGenerator:
     self.commons = commons
     self._id = commons["id"]
     self._isa = commons["isa"]
-    self._thing = commons["thing"]  # fallback type
-    assert self._thing.isglobal()
 
 
   # Returns whether 'handle' refers to another frame.
@@ -98,10 +96,6 @@ class TransitionGenerator:
           nb_edge.inverse = edge
           edge.inverse = nb_edge
           pending.append(value)
-
-    # Assign a fallback type.
-    if info.type is None:
-      info.type = self._thing
 
     # Initialize bookkeeping for all frames pointed to by this frame.
     for p in pending:

--- a/tools/embed.bzl
+++ b/tools/embed.bzl
@@ -4,10 +4,10 @@ def _genembed_impl(ctx):
   # Generate arguments to the embedded data compiler.
   args = []
   for i in ctx.attr.srcs:
-    args += [f.path for f in i.files]
+    args += [f.path for f in i.files.to_list()]
 
   # Run embedded data compiler.
-  ctx.action(
+  ctx.actions.run(
     inputs = ctx.files.srcs,
     outputs = [ctx.outputs.out],
     arguments = ["-o", ctx.outputs.out.path] + args,


### PR DESCRIPTION
Tested by running the trainer + checkpoint eval on a small corpus where "thing" types were removed.
Bonus: Changes to tools/embed.bzl to make it work with the new bazel version.