### PR TITLE
Fix closing recordio files from pyapi

### DIFF
--- a/sling/pyapi/pyrecordio.cc
+++ b/sling/pyapi/pyrecordio.cc
@@ -67,7 +67,7 @@ int PyRecordReader::Init(PyObject *args, PyObject *kwds) {
   if (!CheckIO(File::Open(filename, "r", &f))) return -1;
 
   // Create record reader.
-  reader = new RecordReader(filename, options);
+  reader = new RecordReader(f, options);
   return 0;
 }
 
@@ -276,7 +276,7 @@ int PyRecordWriter::Init(PyObject *args, PyObject *kwds) {
   if (!CheckIO(File::Open(filename, "w", &f))) return -1;
 
   // Create record writer.
-  writer = new RecordWriter(filename, options);
+  writer = new RecordWriter(f, options);
 
   return 0;
 }


### PR DESCRIPTION
Hello there,
great project and sources! I really admire them.

I think I caught 1 bug. I've been using recordio pyapi with posix filesystem, as is. My use case included opening and closing recordio files in a loop and I quickly ran out of file descriptors on linux. I found a reason after investigation. Both `RecordReader` and `RecordWriter` classes should manage lifecycle of `File` pointer with already opened file. But `RecordReader` and `RecordWriter` instances created from pyapi received wrong argument, they opened their second instance of file and first file leaked. This fix worked for me.

So I'm sharing fix back.